### PR TITLE
Changes made to mirror repository are rebased on top of the latest upstream

### DIFF
--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -81,19 +81,11 @@ extension BaseDFUExecutor {
     }
     
     func peripheralDidDisconnect() {
-        // If the disconnection happend for no reason, we can retry to connect to the
-        // same peripheral and continue uploading.
-        guard let error = error else {
-            delegate {
-                $0.dfuStateDidChange(to: .connecting)
-            }
-            peripheral.reconnect()
-            return
-        }
-        // Check if there was an error that needs to be reported now.
+        // Level changes to iOS DFU framework: Report to the higher layer that the DFU has errored out due to a disconnect
         delegate {
-            $0.dfuError(error.error, didOccurWithMessage: error.message)
+            $0.dfuError(DFUError.deviceDisconnected, didOccurWithMessage: "Device disconnected during DFU transfer!")
         }
+        
         // Release the cyclic reference.
         peripheral.destroy()
     }

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -66,7 +66,7 @@ internal class SecureDFUPacket: DFUCharacteristic {
             #else
             let peripheral = characteristic.service.peripheral
             #endif
-            // Make the packet size the first word-aligned value that's less than the maximum
+            // Level changes to iOS DFU framework: Make the packet size the first word-aligned value that's less than the maximum
             packetSize = UInt32(peripheral.maximumWriteValueLength(for: .withoutResponse)) & 0xFFFC
             if packetSize > 20 {
                 // MTU is 3 bytes larger than payload

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -66,8 +66,8 @@ internal class SecureDFUPacket: DFUCharacteristic {
             #else
             let peripheral = characteristic.service.peripheral
             #endif
-            // Make the packet size the first word-aligned value that's less than the maximum.
-            packetSize = UInt32(peripheral.maximumWriteValueLength(for: .withoutResponse)) & 0xFFFFFFFC
+            // Make the packet size the first word-aligned value that's less than the maximum
+            packetSize = UInt32(peripheral.maximumWriteValueLength(for: .withoutResponse)) & 0xFFFC
             if packetSize > 20 {
                 // MTU is 3 bytes larger than payload
                 // (1 octet for Op-Code and 2 octets for Att Handle).
@@ -96,7 +96,7 @@ internal class SecureDFUPacket: DFUCharacteristic {
         #else
         let peripheral = characteristic.service.peripheral
         #endif
-        
+
         // Data may be sent in up-to-20-bytes packets.
         var offset: UInt32 = 0
         var bytesToSend = UInt32(data.count)
@@ -126,7 +126,7 @@ internal class SecureDFUPacket: DFUCharacteristic {
        - progress: An optional progress delegate.
        - queue:    The queue to dispatch progress events on.
        - complete: The completon callback.
-       - report:   Method called in case of an error.       
+       - report:   Method called in case of an error.
      */
     func sendNext(_ prnValue: UInt16, packetsFrom range: Range<Int>, of firmware: DFUFirmware,
                   andReportProgressTo progress: DFUProgressDelegate?, on queue: DispatchQueue,
@@ -140,7 +140,7 @@ internal class SecureDFUPacket: DFUCharacteristic {
         #else
         let peripheral = characteristic.service.peripheral
         #endif
-        
+
         let objectData          = firmware.data.subdata(in: range)
         let objectSizeInBytes   = UInt32(objectData.count)
         let objectSizeInPackets = (objectSizeInBytes + packetSize - 1) / packetSize


### PR DESCRIPTION
I'd like to switch from the [mirror repository](https://github.com/Calthings/iOS_DFU_Library/) to the [fork](https://github.com/Calthings/IOS-Pods-DFU-Library) because it should be easier to maintain our customizations and merge [upstream repository](https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/) changes.
So here all of the changes we made in the mirror are rebased on top of the latest upstream.